### PR TITLE
A couple of missed commits from last PR

### DIFF
--- a/app/commands/test_fixtures/container_pki-backend.csv
+++ b/app/commands/test_fixtures/container_pki-backend.csv
@@ -9,5 +9,6 @@ What should the role be called?,web,OpenEndedQuestion
 What type of Venafi instance will be used?,Venafi-as-a-Service,ClosedQuestion
 What is the Venafi-as-a-Service API Key?,venafiAPIKey,OpenEndedQuestion
 What project zone should be used for issuing certificates?,projectzoneID,OpenEndedQuestion
+Would you like to request any test certificates to check everything is working?,"No, skip",ClosedQuestion
 "You have configured 1 roles, are there more",No that's it,ClosedQuestion
 "You have configured 1 plugins, are there more",No that's it,ClosedQuestion

--- a/app/commands/test_fixtures/container_pki-monitor.csv
+++ b/app/commands/test_fixtures/container_pki-monitor.csv
@@ -15,11 +15,12 @@ Should the same policy be used to import policies for visibility?,"No, use a sep
 Which Venafi policy should be used for importing certificates into?,policy folder\\policy,OpenEndedQuestion
 What type of certificate should Vault use to issue certificates?,Intermediate certificate issued by Venafi,ClosedQuestion
 Which policy should be used to issue the subordinate CA certificate?,policy folder\\policy,OpenEndedQuestion
-What should the common name (CN) of the issuing certificate be?,cn,OpenEndedQuestion
-What should the organisational unit (OU) of the issuing certificate be?,ou,OpenEndedQuestion
-What should the organisation (O) of the issuing certificate be?,organisation,OpenEndedQuestion
-What should the locality (L) of the issuing certificate be?,l,OpenEndedQuestion
-What should the province (P) of the issuing certificate be?,p,OpenEndedQuestion
-What should the country (C) of the issuing certificate be?,c,OpenEndedQuestion
-What should the time-to-live (TTL) of the issuing certificate be?,3h,OpenEndedQuestion
+What should the common name (CN) of the certificate be?,cn,OpenEndedQuestion
+What should the organisational unit (OU) of the certificate be?,ou,OpenEndedQuestion
+What should the organisation (O) of the certificate be?,organisation,OpenEndedQuestion
+What should the locality (L) of the certificate be?,l,OpenEndedQuestion
+What should the province (P) of the certificate be?,p,OpenEndedQuestion
+What should the country (C) of the certificate be?,c,OpenEndedQuestion
+What should the time-to-live (TTL) of the certificate be?,3h,OpenEndedQuestion
+Would you like to request any test certificates to check everything is working?,"No, skip",ClosedQuestion
 "You have configured 1 plugins, are there more",No that's it,ClosedQuestion

--- a/app/commands/test_fixtures/multi_vm_pki-backend.csv
+++ b/app/commands/test_fixtures/multi_vm_pki-backend.csv
@@ -20,5 +20,6 @@ What should the role be called?,web,OpenEndedQuestion
 What type of Venafi instance will be used?,Venafi-as-a-Service,ClosedQuestion
 What is the Venafi-as-a-Service API Key?,venafiAPIKey,OpenEndedQuestion
 What project zone should be used for issuing certificates?,projectzoneID,OpenEndedQuestion
+Would you like to request any test certificates to check everything is working?,"No, skip",ClosedQuestion
 "You have configured 1 roles, are there more",No that's it,ClosedQuestion
 "You have configured 1 plugins, are there more",No that's it,ClosedQuestion

--- a/app/commands/test_fixtures/one_vm_pki-backend.csv
+++ b/app/commands/test_fixtures/one_vm_pki-backend.csv
@@ -14,5 +14,6 @@ What should the role be called?,web,OpenEndedQuestion
 What type of Venafi instance will be used?,Venafi-as-a-Service,ClosedQuestion
 What is the Venafi-as-a-Service API Key?,venafiAPIKey,OpenEndedQuestion
 What project zone should be used for issuing certificates?,projectzoneID,OpenEndedQuestion
+Would you like to request any test certificates to check everything is working?,"No, skip",ClosedQuestion
 "You have configured 1 roles, are there more",No that's it,ClosedQuestion
 "You have configured 1 plugins, are there more",No that's it,ClosedQuestion

--- a/app/plugins/venafi/certificate_request.go
+++ b/app/plugins/venafi/certificate_request.go
@@ -1,7 +1,10 @@
 package venafi
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/opencredo/venafi-vault-wizard/app/questions"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -27,6 +30,54 @@ func (c *CertificateRequest) ToMap() map[string]interface{} {
 	}
 }
 
+func GenerateCertRequestConfig(questioner questions.Questioner) (*CertificateRequest, error) {
+	q := map[string]questions.Question{
+		"cn": questioner.NewOpenEndedQuestion(&questions.OpenEndedQuestion{
+			Question: "What should the common name (CN) of the certificate be?",
+		}),
+		"ou": questioner.NewOpenEndedQuestion(&questions.OpenEndedQuestion{
+			Question: "What should the organisational unit (OU) of the certificate be?",
+		}),
+		"o": questioner.NewOpenEndedQuestion(&questions.OpenEndedQuestion{
+			Question: "What should the organisation (O) of the certificate be?",
+		}),
+		"l": questioner.NewOpenEndedQuestion(&questions.OpenEndedQuestion{
+			Question: "What should the locality (L) of the certificate be?",
+		}),
+		"p": questioner.NewOpenEndedQuestion(&questions.OpenEndedQuestion{
+			Question: "What should the province (P) of the certificate be?",
+		}),
+		"c": questioner.NewOpenEndedQuestion(&questions.OpenEndedQuestion{
+			Question: "What should the country (C) of the certificate be?",
+		}),
+		"ttl": questioner.NewOpenEndedQuestion(&questions.OpenEndedQuestion{
+			Question: "What should the time-to-live (TTL) of the certificate be?",
+		}),
+	}
+	err := questions.AskQuestions([]questions.Question{
+		q["cn"],
+		q["ou"],
+		q["o"],
+		q["l"],
+		q["p"],
+		q["c"],
+		q["ttl"],
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &CertificateRequest{
+		CommonName:   string(q["cn"].Answer()),
+		OU:           string(q["ou"].Answer()),
+		Organisation: string(q["o"].Answer()),
+		Locality:     string(q["l"].Answer()),
+		Province:     string(q["p"].Answer()),
+		Country:      string(q["c"].Answer()),
+		TTL:          string(q["ttl"].Answer()),
+	}, nil
+}
+
 func (c *CertificateRequest) WriteHCL(hclBody *hclwrite.Body) {
 	hclBody.SetAttributeValue("common_name", cty.StringVal(c.CommonName))
 	hclBody.SetAttributeValue("ou", cty.StringVal(c.OU))
@@ -35,4 +86,44 @@ func (c *CertificateRequest) WriteHCL(hclBody *hclwrite.Body) {
 	hclBody.SetAttributeValue("province", cty.StringVal(c.Province))
 	hclBody.SetAttributeValue("country", cty.StringVal(c.Country))
 	hclBody.SetAttributeValue("ttl", cty.StringVal(c.TTL))
+}
+
+func AskForTestCertificates(questioner questions.Questioner) ([]CertificateRequest, error) {
+	anyCSRsQuestion := questioner.NewClosedQuestion(&questions.ClosedQuestion{
+		Question: "Would you like to request any test certificates to check everything is working?",
+		Items:    []string{"Yes", "No, skip"},
+	})
+	err := anyCSRsQuestion.Ask()
+	if err != nil {
+		return nil, err
+	}
+
+	if anyCSRsQuestion.Answer() == "No, skip" {
+		return nil, nil
+	}
+
+	var csrs []CertificateRequest
+	for i := 1; true; i++ {
+		certificateRequest, err := GenerateCertRequestConfig(questioner)
+		if err != nil {
+			return nil, err
+		}
+
+		csrs = append(csrs, *certificateRequest)
+
+		moreCSRsQuestion := questioner.NewClosedQuestion(&questions.ClosedQuestion{
+			Question: fmt.Sprintf("You have configured %d test certificates, are there more", i),
+			Items:    []string{"Yes", "No that's it"},
+		})
+		err = moreCSRsQuestion.Ask()
+		if err != nil {
+			return nil, err
+		}
+
+		if moreCSRsQuestion.Answer() != "Yes" {
+			break
+		}
+	}
+
+	return csrs, nil
 }


### PR DESCRIPTION
I tried to push some commits while GitHub was down and then promptly forgot about them!

Two small things:

- Firstly the `pki-monitor` plugin only supports one role, so I removed the loop from config generation which asked for multiple roles
- Secondly I added questions for `test_certificates` so these could be generated too