### PR TITLE
Add new optional_config block to pki-backend plugin

### DIFF
--- a/app/commands/test_fixtures/container_pki-backend.csv
+++ b/app/commands/test_fixtures/container_pki-backend.csv
@@ -9,6 +9,7 @@ What should the role be called?,web,OpenEndedQuestion
 What type of Venafi instance will be used?,Venafi-as-a-Service,ClosedQuestion
 What is the Venafi-as-a-Service API Key?,venafiAPIKey,OpenEndedQuestion
 What project zone should be used for issuing certificates?,projectzoneID,OpenEndedQuestion
+Do you want to configure optional parameters?,"No",ClosedQuestion
 Would you like to request any test certificates to check everything is working?,"No, skip",ClosedQuestion
 "You have configured 1 roles, are there more",No that's it,ClosedQuestion
 "You have configured 1 plugins, are there more",No that's it,ClosedQuestion

--- a/app/commands/test_fixtures/multi_vm_pki-backend.csv
+++ b/app/commands/test_fixtures/multi_vm_pki-backend.csv
@@ -20,6 +20,7 @@ What should the role be called?,web,OpenEndedQuestion
 What type of Venafi instance will be used?,Venafi-as-a-Service,ClosedQuestion
 What is the Venafi-as-a-Service API Key?,venafiAPIKey,OpenEndedQuestion
 What project zone should be used for issuing certificates?,projectzoneID,OpenEndedQuestion
+Do you want to configure optional parameters?,"No",ClosedQuestion
 Would you like to request any test certificates to check everything is working?,"No, skip",ClosedQuestion
 "You have configured 1 roles, are there more",No that's it,ClosedQuestion
 "You have configured 1 plugins, are there more",No that's it,ClosedQuestion

--- a/app/commands/test_fixtures/one_vm_pki-backend.csv
+++ b/app/commands/test_fixtures/one_vm_pki-backend.csv
@@ -14,6 +14,7 @@ What should the role be called?,web,OpenEndedQuestion
 What type of Venafi instance will be used?,Venafi-as-a-Service,ClosedQuestion
 What is the Venafi-as-a-Service API Key?,venafiAPIKey,OpenEndedQuestion
 What project zone should be used for issuing certificates?,projectzoneID,OpenEndedQuestion
+Do you want to configure optional parameters?,"No",ClosedQuestion
 Would you like to request any test certificates to check everything is working?,"No, skip",ClosedQuestion
 "You have configured 1 roles, are there more",No that's it,ClosedQuestion
 "You have configured 1 plugins, are there more",No that's it,ClosedQuestion

--- a/app/plugins/venafi/optional_config.go
+++ b/app/plugins/venafi/optional_config.go
@@ -132,6 +132,10 @@ func (oc *OptionalConfig) Validate() error {
 }
 
 func (oc *OptionalConfig) GetAsMap() map[string]interface{} {
+	if oc == nil {
+		return map[string]interface{}{}
+	}
+
 	return map[string]interface{}{
 		"ttl":            oc.TTL,
 		"max_ttl":        oc.MaxTTL,

--- a/app/plugins/venafi/pki-backend/venafi-pki-backend.go
+++ b/app/plugins/venafi/pki-backend/venafi-pki-backend.go
@@ -39,6 +39,7 @@ func (c *VenafiPKIBackendConfig) Configure(report reporter.Report, vaultClient a
 			fmt.Sprintf("%s/roles/%s", c.MountPath, role.Name),
 			role.Secret.Name,
 			role.Zone,
+			role.OptionalConfig.GetAsMap(),
 		)
 		if err != nil {
 			return err

--- a/app/plugins/venafi/pki-backend/venafi_role.go
+++ b/app/plugins/venafi/pki-backend/venafi_role.go
@@ -11,13 +11,14 @@ func ConfigureVenafiRole(
 	reportSection reporter.Section,
 	vaultClient api.VaultAPIClient,
 	rolePath, secretName, zone string,
+	optionalParameters map[string]interface{},
 ) error {
 	check := reportSection.AddCheck("Adding Venafi role...")
 
-	_, err := vaultClient.WriteValue(rolePath, map[string]interface{}{
-		"venafi_secret": secretName,
-		"zone":          zone,
-	})
+	optionalParameters["venafi_secret"] = secretName
+	optionalParameters["zone"] = zone
+
+	_, err := vaultClient.WriteValue(rolePath, optionalParameters)
 	if err != nil {
 		check.Errorf("Error configuring Venafi role: %s", err)
 		return err


### PR DESCRIPTION
It was implemented and working for the `pki-monitor` plugin so I thought I'd add it to the other venafi plugin too.

There was also a bug in the `GetAsMap()` function where it would panic if called when `optionalConfig==nil`.
I added a nil check to catch this and return and empty map.

Lastly I had to update the `generate_config` tests to include the new question about optional parameters for this plugin.
These are already tested in the `container-pki-monitor_optional` tests so I said "No" to the optional config in all of the other tests.