### PR TITLE
Remove leftover Venafi Cloud references in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 -	Website: TBC
 -	Source: https://github.com/opencredo/venafi-vault-wizard
 -	Venafi Community Support: https://support.venafi.com/hc/en-us/community/topics
--	Venafi Cloud: https://www.venafi.com/venaficloud
 -	HashiCorp Discuss: https://discuss.hashicorp.com/c/vault/30
 
 This repository is home to the `venafi-vault-wizard` which can be used to verify the setup of HashiCorp Vault with Venafi as a Service and TPP.
@@ -12,7 +11,7 @@ This repository is home to the `venafi-vault-wizard` which can be used to verify
 
 -	[Go](https://golang.org/doc/install) 1.16
 -	[Vagrant](https://www.vagrantup.com/downloads)
--	[Venafi Cloud Account & Zone](https://ui.venafi.cloud/login) or TPP instance
+-	[Venafi as a Service Account & Zone](https://ui.venafi.cloud/login) or TPP instance
 
 ## Docs
 

--- a/docs/config-reference/plugin.md
+++ b/docs/config-reference/plugin.md
@@ -1,10 +1,3 @@
----
-layout: "venafi-vault-wizard"
-page_title: "VVW: plugin"
-description: |-
-Venafi Vault Wizard configuration that represents a plugin to be installed and configured.
----
-
 # Configuration: plugin
 
 Venafi Vault Wizard configuration that represents a plugin to be installed and configured.
@@ -33,7 +26,7 @@ plugin "venafi-pki-backend" "pki-backend" {
   # vault write pki-backend/issue/web_server common_name=test.test.test
   role "web_server" {
     # Connection details for Venafi TPP
-    # If using Venafi Cloud, replace the venafi_tpp block with a venafi_cloud one and specify the "apikey" attribute instead
+    # If using Venafi as a Service, replace the venafi_tpp block with a venafi_vaas one and specify the "apikey" attribute instead
     secret "tpp" {
       venafi_tpp {
         url = env("TPP_URL")

--- a/docs/config-reference/plugins/venafi-pki-backend.md
+++ b/docs/config-reference/plugins/venafi-pki-backend.md
@@ -1,14 +1,6 @@
----
-layout: "venafi-vault-wizard"
-page_title: "VVW: venafi-pki-backend"
-description: |-
-Venafi Vault Wizard plugin that installs the venafi-pki-backend Vault plugin to a Vault cluster.
----
-
 # Plugin: venafi-pki-backend
 
 Configures the `venafi-pki-backend` plugin to be installed into a Vault cluster through the Venafi Vault Wizard. 
-
 
 ## Example Usage
 
@@ -23,7 +15,7 @@ plugin "venafi-pki-backend" "pki-backend" {
   # vault write pki-backend/issue/web_server common_name=test.test.test
   role "web_server" {
     # Connection details for Venafi TPP
-    # If using Venafi Cloud, replace the venafi_tpp block with a venafi_cloud one and specify the "apikey" attribute instead
+    # If using Venafi as a Service, replace the venafi_tpp block with a venafi_vaas one and specify the "apikey" attribute instead
     secret "tpp" {
       venafi_tpp {
         url = env("TPP_URL")
@@ -76,7 +68,7 @@ The `role` block supports the following blocks:
 The `secret` block must contain exactly one of the following blocks:
 
 * `venafi_tpp` - Required when using Venafi's Trust Protection Platform
-* `venafi_cloud` - Required when using Venafi as a Service
+* `venafi_vaas` - Required when using Venafi as a Service
 
 ##### venafi_tpp
 
@@ -89,7 +81,7 @@ It is recommended to use `env("TPP_PASSWORD")` to retrieve this from an environm
 
 * `zone` - (Required) The path of the policy within TPP, from which certificates will be requested.
 
-##### venafi_cloud
+##### venafi_vaas
 
 * `apikey` - (Required) A String with an API Key with access to Venafi as a Service.
 

--- a/docs/config-reference/plugins/venafi-pki-monitor.md
+++ b/docs/config-reference/plugins/venafi-pki-monitor.md
@@ -1,10 +1,3 @@
----
-layout: "venafi-vault-wizard"
-page_title: "VVW: venafi-pki-monitor"
-description: |-
-Venafi Vault Wizard plugin that installs the venafi-pki-monitor Vault plugin to a Vault cluster.
----
-
 # Plugin: venfai-pki-monitor
 
 Configures the `venafi-pki-monitor` plugin to be installed into a Vault cluster through the Venafi Vault Wizard.
@@ -23,7 +16,7 @@ plugin "venafi-pki-monitor" "pki-monitor" {
   # vault write pki-monitor/issue/web_server common_name=test.test.test
   role "web_server" {
     # Connection details for Venafi TPP
-    # If using Venafi Cloud, replace the venafi_tpp block with a venafi_cloud one and specify the "apikey" attribute instead
+    # If using Venafi as a Service, replace the venafi_tpp block with a venafi_vaas one and specify the "apikey" attribute instead
     secret "tpp" {
       venafi_tpp {
         url = env("TPP_URL")
@@ -106,7 +99,7 @@ The `role` block supports the following blocks:
 The `secret` block must contain exactly one of the following blocks:
 
 * `venafi_tpp` - Required when using Venafi's Trust Protection Platform
-* `venafi_cloud` - Required when using Venafi as a Service
+* `venafi_vaas` - Required when using Venafi as a Service
 
 ##### venafi_tpp
 
@@ -119,7 +112,7 @@ It is recommended to use `env("TPP_PASSWORD")` to retrieve this from an environm
 
 * `zone` - (Required) The path of the policy within TPP, from which certificates will be requested.
 
-##### venafi_cloud
+##### venafi_vaas
 
 * `apikey` - (Required) A String with an API Key with access to Venafi as a Service.
 

--- a/docs/config-reference/vault.md
+++ b/docs/config-reference/vault.md
@@ -1,10 +1,3 @@
----
-layout: "venafi-vault-wizard"
-page_title: "VVW: vault"
-description: |-
-Venafi Vault Wizard configuration that represents a Vault cluster where Vault plugins will be installed and configured.
----
-
 # Configuration: vault
 
 Venafi Vault Wizard configuration that represents a Vault cluster where Vault plugins will be installed and configured.


### PR DESCRIPTION
Also tidied up some of the top matter sections of the docs copied over from Terraform docs, as GitHub doesn't render those nicely