### PR TITLE
Trim space from server arch strings in `CheckOSArch()` before comparing

### DIFF
--- a/app/vault/ssh/ssh.go
+++ b/app/vault/ssh/ssh.go
@@ -59,8 +59,8 @@ func (c *sshClient) CheckOSArch() (string, string, error) {
 		return "", "", err
 	}
 	outputSplit := strings.Split(string(output), " ")
-	osType := outputSplit[0]
-	arch := outputSplit[1]
+	osType := strings.TrimSpace(outputSplit[0])
+	arch := strings.TrimSpace(outputSplit[1])
 
 	return osType, arch, nil
 }


### PR DESCRIPTION
I had a bug where the 64-bit arch check failed due to `"x86_64" != "x86_64\n"`.
To fix this, I added a `strings.TrimSpace()` to each of the OS and Arch strings.