### PR TITLE
Add gofmt step to Lint GitHub Action

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,6 +8,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: "Lint"
         uses: golangci/golangci-lint-action@v2
+      - name: "Format"
+        uses: Jerome1337/gofmt-action@v1.0.4
+        with:
+          gofmt-flags: '-l -d'
   test:
     name: "Build and Test"
     runs-on: ubuntu-latest


### PR DESCRIPTION
The lint action doesn't currently check for `go fmt` and it's quite easy to forget to do it, so this lint step should help to keep formatting fixes out of future diffs and make them easier to review