### PR TITLE
Allow referencing a vault secret in config files

### DIFF
--- a/app/commands/generate_config_test.go
+++ b/app/commands/generate_config_test.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"encoding/csv"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -348,7 +349,11 @@ func TestGenerateConfig(t *testing.T) {
 
 			commands.GenerateConfig(testFileName, questioner)
 
-			actualConfig, err := config.NewConfigFromFile(testFileName)
+			configFileBytes, err := ioutil.ReadFile(testFileName)
+			assert.NoError(t, err)
+
+			configParser := config.NewConfigParser(testFileName, configFileBytes)
+			actualConfig, err := configParser.GetConfig()
 			assert.NoError(t, err)
 
 			diff := cmp.Diff(

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -2,11 +2,11 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsimple"
+	"github.com/opencredo/venafi-vault-wizard/app/vault/api"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
 
@@ -14,43 +14,116 @@ import (
 	"github.com/opencredo/venafi-vault-wizard/app/plugins/lookup"
 )
 
+// configStage1 is a private struct used to decode only the Vault API parameters. This allows the next stage of decoding
+// to retrieve values from the Vault API
+type configStage1 struct {
+	Vault struct {
+		Address string   `hcl:"api_address"`
+		Token   string   `hcl:"token"`
+		Rest    hcl.Body `hcl:",remain"`
+	} `hcl:"vault,block"`
+	Rest hcl.Body `hcl:",remain"`
+}
+
 type Config struct {
 	Vault   VaultConfig            `hcl:"vault,block"`
 	Plugins []plugins.PluginConfig `hcl:"plugin,block"`
 }
 
-// NewConfig decodes an HCL configuration file into a Config struct, returning an error upon failure. It takes filename
-// as a parameter to use in error messages while parsing, and a byte slice containing the actual configuration itself.
-// It then uses hclsimple to parse the configuration and validates it using Config.Validate() before returning it.
-// If this function returns without an error then the config should be valid to use.
-func NewConfig(filename string, src []byte) (*Config, error) {
-	config := new(Config)
+type ConfigParser struct {
+	fileName     string
+	fileContents []byte
+	evalContext  *hcl.EvalContext
+}
 
-	// Add a custom env function to the context so that config files can use it
-	configEvaluationContext := &hcl.EvalContext{
-		Functions: map[string]function.Function{
-			"env": function.New(&function.Spec{
-				Params: []function.Parameter{
-					{
-						Name:             "name",
-						Type:             cty.String,
-						AllowDynamicType: true,
+// NewConfigParser returns a ConfigParser which, initially, only supports an `env()` function in the config. Calling
+// ConfigParser.SetVaultClient afterwards adds support for the `secret()` function too, to allow parameters to be
+// retrieved from Vault. The ConfigParser.GetVaultAPIDetails method can be used to partially decode the config to get
+// just the API address and token, which is sufficient for creating an api.VaultAPIClient to give to
+// ConfigParser.SetVaultClient. This means that the rest of the config can be fully decoded afterwards using
+// ConfigParser.GetConfig, and the rest of the config can take advantage of the `secret()` function. This function
+// should be provided with the config file name (for constructing the diagnostic messages), and a byte slice containing
+// the contents of the config file.
+func NewConfigParser(filename string, src []byte) *ConfigParser {
+	return &ConfigParser{
+		fileName:     filename,
+		fileContents: src,
+		evalContext: &hcl.EvalContext{
+			Functions: map[string]function.Function{
+				"env": function.New(&function.Spec{
+					Params: []function.Parameter{
+						{
+							Name:             "name",
+							Type:             cty.String,
+							AllowDynamicType: true,
+						},
 					},
-				},
-				Type: function.StaticReturnType(cty.String),
-				Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-					env := os.Getenv(args[0].AsString())
-					if env == "" {
-						return cty.NullVal(cty.String), fmt.Errorf("environment variable not set")
-					}
+					Type: function.StaticReturnType(cty.String),
+					Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+						env := os.Getenv(args[0].AsString())
+						if env == "" {
+							return cty.NilVal, fmt.Errorf("environment variable not set")
+						}
 
-					return cty.StringVal(env), nil
-				},
-			}),
+						return cty.StringVal(env), nil
+					},
+				}),
+			},
 		},
 	}
+}
 
-	err := hclsimple.Decode(filename, src, configEvaluationContext, config)
+// GetVaultAPIDetails partially decodes the config in order to retrieve an API address and Token for Vault.
+func (p *ConfigParser) GetVaultAPIDetails() (apiAddr, token string, err error) {
+	config := new(configStage1)
+
+	err = hclsimple.Decode(p.fileName, p.fileContents, p.evalContext, config)
+	if err != nil {
+		return "", "", err
+	}
+
+	return config.Vault.Address, config.Vault.Token, nil
+}
+
+// SetVaultClient provides the config parser with access to the Vault API which allows the config to use the `secret()`
+// function to retrieve Vault secrets automatically. Unless this method is called, ConfigParser.GetConfig will fail if
+// the config tries to use the `secret()` function.
+func (p *ConfigParser) SetVaultClient(vaultClient api.VaultAPIClient) {
+	p.evalContext.Functions["secret"] = function.New(&function.Spec{
+		Params: []function.Parameter{
+			{
+				Name:             "vaultPath",
+				Type:             cty.String,
+				AllowDynamicType: true,
+			},
+			{
+				Name:             "fieldKey",
+				Type:             cty.String,
+				AllowDynamicType: true,
+			},
+		},
+		Type: function.StaticReturnType(cty.String),
+		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+			path := args[0].AsString()
+			field := args[1].AsString()
+
+			value, err := vaultClient.ReadValue(path)
+			if err != nil {
+				return cty.NilVal, fmt.Errorf("error reading Vault secret: %w", err)
+			}
+
+			return cty.StringVal(fmt.Sprintf("%v", value[field])), nil
+		},
+	})
+}
+
+// GetConfig decodes an HCL configuration file into a Config struct, returning an error upon failure.
+// It uses hclsimple to parse the configuration and validates it using Config.Validate() before returning it.
+// If this function returns without an error then the config should be valid to use.
+func (p *ConfigParser) GetConfig() (*Config, error) {
+	config := new(Config)
+
+	err := hclsimple.Decode(p.fileName, p.fileContents, p.evalContext, config)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +139,7 @@ func NewConfig(filename string, src []byte) (*Config, error) {
 			return nil, err
 		}
 
-		err = pluginImpl.ParseConfig(&plugin, configEvaluationContext)
+		err = pluginImpl.ParseConfig(&plugin, p.evalContext)
 		if err != nil {
 			return nil, err
 		}
@@ -80,20 +153,6 @@ func NewConfig(filename string, src []byte) (*Config, error) {
 	}
 
 	return config, nil
-}
-
-// NewConfigFromFile reads the file from filename and calls NewConfig with its contents
-func NewConfigFromFile(filename string) (*Config, error) {
-	src, err := ioutil.ReadFile(filename)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("error config file %s not found: %w", filename, err)
-		}
-
-		return nil, fmt.Errorf("can't read %s: %w", filename, err)
-	}
-
-	return NewConfig(filename, src)
 }
 
 func (c *Config) Validate() error {

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -77,7 +77,8 @@ func TestNewConfig(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			got, err := NewConfig("vvwconfig.hcl", []byte(tt.config))
+			parser := NewConfigParser("vvwconfig.hcl", []byte(tt.config))
+			got, err := parser.GetConfig()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewConfig() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/app/vault/lib/wrapper.go
+++ b/app/vault/lib/wrapper.go
@@ -1,6 +1,10 @@
 package lib
 
-import vaultAPI "github.com/hashicorp/vault/api"
+import (
+	"fmt"
+
+	vaultAPI "github.com/hashicorp/vault/api"
+)
 
 // VaultAPIWrapper encapsulates the dependency on the HashiCorp Go Vault package, both to allow it to be injected, but
 // also to make its interface slightly simpler to its clients
@@ -31,7 +35,11 @@ func (v *vaultAPIClient) Read(path string) (map[string]interface{}, error) {
 		return nil, normaliseError(err)
 	}
 
-	return secret.Data, nil
+	if secret != nil {
+		return secret.Data, nil
+	} else {
+		return nil, fmt.Errorf("no data found at path %s", path)
+	}
 }
 
 func (v *vaultAPIClient) Write(path string, data map[string]interface{}) (map[string]interface{}, error) {


### PR DESCRIPTION
In addition to the existing `env()` function in the config file, this PR adds an alternative `secret()` function to allow bringing values in from Vault for use in the rest of the configuration. The `api_address` and `token` attributes in the `vault` block must only use literal values or `env()`, but then any other attribute may take advantage of the new `secret()` function. This is because the token and API address are needed to connect to Vault before the `secret()` function can be used, otherwise there is a chicken and egg problem.