### PR TITLE
Correct examples after updates

### DIFF
--- a/examples/consul_ha_cluster_vagrant/README.md
+++ b/examples/consul_ha_cluster_vagrant/README.md
@@ -2,11 +2,11 @@
 
 This test environment spins up a 3-node Vault cluster on 3 VMs, and a Consul server on a 4th VM using Vagrant.
 These nodes all have the same SSH credentials for ease: `vagrant` for both the username and password.
-The Consul server's IP address is `192.168.33.8` and the Vault nodes' IP addresses are as follows:
+The Consul server's IP address is `192.168.56.8` and the Vault nodes' IP addresses are as follows:
 
-- `192.168.33.10`
-- `192.168.33.11`
-- `192.168.33.12`
+- `192.168.56.10`
+- `192.168.56.11`
+- `192.168.56.12`
 
 The first node is the leader by default, unless it is restarted, or some other re-election takes place.
 If another node becomes leader, then the `vvw.hcl` config file for this environment will need updating to set the `api_address` to the new leader's IP address.
@@ -55,7 +55,7 @@ Feel free to also set the `VAULT_ADDR` variable to allow using the normal `vault
 
 ```shell
 $ export VAULT_TOKEN="s.dgjfnskdfgnksd"
-$ export VAULT_ADDR="http://192.168.33.10:8200"
+$ export VAULT_ADDR="http://192.168.56.10:8200"
 $ vault status
 ```
 

--- a/examples/consul_ha_cluster_vagrant/Vagrantfile
+++ b/examples/consul_ha_cluster_vagrant/Vagrantfile
@@ -18,7 +18,7 @@ Vagrant.configure("2") do |config|
   config.ssh.password = "vagrant"
 
   config.vm.define "consul-server" do |node|
-    node_ip = "192.168.33.8"
+    node_ip = "192.168.56.8"
 
     # Create a private network, which allows host-only access to the machine
     # using a specific IP.
@@ -32,7 +32,7 @@ Vagrant.configure("2") do |config|
 
   (0..2).each do |i|
     config.vm.define "vault-#{i}" do |node|
-      node_ip = "192.168.33.1#{i}"
+      node_ip = "192.168.56.1#{i}"
       # Create a private network, which allows host-only access to the machine
       # using a specific IP.
       node.vm.network "private_network", ip: node_ip

--- a/examples/consul_ha_cluster_vagrant/bootstrap.sh
+++ b/examples/consul_ha_cluster_vagrant/bootstrap.sh
@@ -11,8 +11,8 @@ __node_ip=$2
 __node_num=$3
 
 # Hardcoded IPs of initial leader nodes
-__vault_leader_ip="192.168.33.10"
-__consul_leader_ip="192.168.33.8"
+__vault_leader_ip="192.168.56.10"
+__consul_leader_ip="192.168.56.8"
 
 # Called at bottom of file
 main() {
@@ -156,7 +156,7 @@ initialise_follower_node() {
   echo "Attempting to SCP the keys"
   sshpass -p vagrant \
   scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
-  vagrant@192.168.33.10:/home/vagrant/init-keys.json /home/vagrant/init-keys.json
+  vagrant@192.168.56.10:/home/vagrant/init-keys.json /home/vagrant/init-keys.json
 
   unseal_vault
 }

--- a/examples/consul_ha_cluster_vagrant/tpp-vvw.hcl
+++ b/examples/consul_ha_cluster_vagrant/tpp-vvw.hcl
@@ -1,23 +1,23 @@
 vault {
-  api_address = "http://192.168.33.10:8200"
+  api_address = "http://192.168.56.10:8200"
   token = env("VAULT_TOKEN")
 
   ssh {
-    hostname = "192.168.33.10"
+    hostname = "192.168.56.10"
     username = "vagrant"
     password = "vagrant"
     port = 22
   }
 
   ssh {
-    hostname = "192.168.33.11"
+    hostname = "192.168.56.11"
     username = "vagrant"
     password = "vagrant"
     port = 22
   }
 
   ssh {
-    hostname = "192.168.33.12"
+    hostname = "192.168.56.12"
     username = "vagrant"
     password = "vagrant"
     port = 22
@@ -91,7 +91,7 @@ plugin "venafi-pki-monitor" "pki-monitor" {
 }
 
 plugin "venafi-pki-backend" "pki-backend" {
-  version = "v0.9.0"
+  version = "v0.10.3"
 
   # A role called "web_server" can be used with:
   # vault write pki-backend/issue/web_server common_name=test.test.test

--- a/examples/consul_ha_cluster_vagrant/vaas-vvw.hcl
+++ b/examples/consul_ha_cluster_vagrant/vaas-vvw.hcl
@@ -1,23 +1,23 @@
 vault {
-  api_address = "http://192.168.33.10:8200"
+  api_address = "http://192.168.56.10:8200"
   token = env("VAULT_TOKEN")
 
   ssh {
-    hostname = "192.168.33.10"
+    hostname = "192.168.56.10"
     username = "vagrant"
     password = "vagrant"
     port = 22
   }
 
   ssh {
-    hostname = "192.168.33.11"
+    hostname = "192.168.56.11"
     username = "vagrant"
     password = "vagrant"
     port = 22
   }
 
   ssh {
-    hostname = "192.168.33.12"
+    hostname = "192.168.56.12"
     username = "vagrant"
     password = "vagrant"
     port = 22
@@ -85,7 +85,7 @@ plugin "venafi-pki-monitor" "pki-monitor" {
 }
 
 plugin "venafi-pki-backend" "pki-backend" {
-  version = "v0.9.0"
+  version = "v0.10.3"
 
   # A role called "web_server" can be used with:
   # vault write pki-backend/issue/web_server common_name=test.test.test

--- a/examples/helm/Dockerfile
+++ b/examples/helm/Dockerfile
@@ -1,6 +1,7 @@
 FROM vault:1.7.1
 
-ARG PLUGIN_VERSION=0.9.0
+ARG PKI_MONITOR_PLUGIN_VERSION=0.9.0
+ARG PKI_BACKEND_PLUGIN_VERSION=0.9.0
 
 RUN set -eux; \
     apkArch="$(apk --print-arch)"; \
@@ -11,12 +12,12 @@ RUN set -eux; \
     esac && \
     mkdir -p /tmp/plugin_dl && \
     cd /tmp/plugin_dl && \
-    wget https://github.com/Venafi/vault-pki-monitor-venafi/releases/download/v${PLUGIN_VERSION}/venafi-pki-monitor_v${PLUGIN_VERSION}_linux${ARCH}_optional.zip && \
-    wget https://github.com/Venafi/vault-pki-backend-venafi/releases/download/v${PLUGIN_VERSION}/venafi-pki-backend_v${PLUGIN_VERSION}_linux${ARCH}.zip && \
+    wget https://github.com/Venafi/vault-pki-monitor-venafi/releases/download/v${PKI_MONITOR_PLUGIN_VERSION}/venafi-pki-monitor_v${PKI_MONITOR_PLUGIN_VERSION}_linux${ARCH}_optional.zip && \
+    wget https://github.com/Venafi/vault-pki-backend-venafi/releases/download/v${PKI_BACKEND_PLUGIN_VERSION}/venafi-pki-backend_v${PKI_BACKEND_PLUGIN_VERSION}_linux${ARCH}.zip && \
     mkdir -p /vault/plugins && \
-    unzip venafi-pki-monitor_v${PLUGIN_VERSION}_linux${ARCH}_optional.zip && \
-    cp venafi-pki-monitor_optional /vault/plugins/venafi-pki-monitor_v${PLUGIN_VERSION} && \
-    unzip venafi-pki-backend_v${PLUGIN_VERSION}_linux${ARCH}.zip && \
-    cp venafi-pki-backend /vault/plugins/venafi-pki-backend_v${PLUGIN_VERSION} && \
+    unzip venafi-pki-monitor_v${PKI_MONITOR_PLUGIN_VERSION}_linux${ARCH}_optional.zip && \
+    cp venafi-pki-monitor_optional /vault/plugins/venafi-pki-monitor_v${PKI_MONITOR_PLUGIN_VERSION} && \
+    unzip venafi-pki-backend_v${PKI_BACKEND_PLUGIN_VERSION}_linux${ARCH}.zip && \
+    cp venafi-pki-backend /vault/plugins/venafi-pki-backend_v${PKI_BACKEND_PLUGIN_VERSION} && \
     cd /tmp && \
     rm -rf /tmp/plugin_dl

--- a/examples/helm/Makefile
+++ b/examples/helm/Makefile
@@ -1,7 +1,8 @@
 IMAGE_NAME=vault-with-venafi-plugins
-PLUGIN_VERSION=0.9.0
+PKI_MONITOR_PLUGIN_VERSION=0.9.0
+PKI_BACKEND_PLUGIN_VERSION=0.10.3
 
 .PHONY: build
 build:
-	@echo "Building Docker image with version ${PLUGIN_VERSION} of the Venafi plugins"
-	docker build -t ${IMAGE_NAME} --build-arg PLUGIN_VERSION=${PLUGIN_VERSION} .
+	@echo "Building Docker image with version ${PKI_MONITOR_PLUGIN_VERSION} of the pki monitor and version ${PKI_BACKEND_PLUGIN_VERSION} of the pki backend venafi plugins"
+	docker build -t ${IMAGE_NAME} --build-arg PKI_MONITOR_PLUGIN_VERSION=${PKI_MONITOR_PLUGIN_VERSION} --build-arg PKI_BACKEND_PLUGIN_VERSION=${PKI_BACKEND_PLUGIN_VERSION} .

--- a/examples/helm/tpp-vvw.hcl
+++ b/examples/helm/tpp-vvw.hcl
@@ -71,7 +71,7 @@ plugin "venafi-pki-monitor" "pki-monitor" {
 }
 
 plugin "venafi-pki-backend" "pki-backend" {
-  version = "v0.9.0"
+  version = "v0.10.3"
 
   # A role called "web_server" can be used with:
   # vault write pki-backend/issue/web_server common_name=test.test.test

--- a/examples/helm/vaas-vvw.hcl
+++ b/examples/helm/vaas-vvw.hcl
@@ -65,7 +65,7 @@ plugin "venafi-pki-monitor" "pki-monitor" {
 }
 
 plugin "venafi-pki-backend" "pki-backend" {
-  version = "v0.9.0"
+  version = "v0.10.3"
 
   # A role called "web_server" can be used with:
   # vault write pki-backend/issue/web_server common_name=test.test.test

--- a/examples/integrated_storage_ha_cluster_vagrant/README.md
+++ b/examples/integrated_storage_ha_cluster_vagrant/README.md
@@ -4,9 +4,9 @@ This test environment spins up a 3-node Vault cluster on 3 VMs using Vagrant.
 These nodes all have the same SSH credentials for ease: `vagrant` for both the username and password.
 The nodes' IP addresses are as follows:
 
-- `192.168.33.10`
-- `192.168.33.11`
-- `192.168.33.12`
+- `192.168.56.10`
+- `192.168.56.11`
+- `192.168.56.12`
 
 The first node is the leader by default, unless it is restarted, or some other re-election takes place.
 If another node becomes leader, then the `vvw.hcl` config file for this environment will need updating to set the `api_address` to the new leader's IP address.
@@ -54,7 +54,7 @@ Feel free to also set the `VAULT_ADDR` variable to allow using the normal `vault
 
 ```shell
 $ export VAULT_TOKEN="s.dgjfnskdfgnksd"
-$ export VAULT_ADDR="http://192.168.33.10:8200"
+$ export VAULT_ADDR="http://192.168.56.10:8200"
 $ vault status
 ```
 

--- a/examples/integrated_storage_ha_cluster_vagrant/Vagrantfile
+++ b/examples/integrated_storage_ha_cluster_vagrant/Vagrantfile
@@ -19,7 +19,7 @@ Vagrant.configure("2") do |config|
 
   (0..2).each do |i|
     config.vm.define "vault-#{i}" do |node|
-      node_ip = "192.168.33.1#{i}"
+      node_ip = "192.168.56.1#{i}"
       # Create a private network, which allows host-only access to the machine
       # using a specific IP.
       node.vm.network "private_network", ip: node_ip

--- a/examples/integrated_storage_ha_cluster_vagrant/bootstrap.sh
+++ b/examples/integrated_storage_ha_cluster_vagrant/bootstrap.sh
@@ -7,7 +7,7 @@ set -o nounset
 
 __node_ip=$1
 __node_num=$2
-__leader_ip="192.168.33.10"
+__leader_ip="192.168.56.10"
 
 # Called at bottom of file
 main() {
@@ -91,7 +91,7 @@ initialise_follower_node() {
   echo "Attempting to SCP the keys"
   sshpass -p vagrant \
   scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
-  vagrant@192.168.33.10:/home/vagrant/init-keys.json /home/vagrant/init-keys.json
+  vagrant@192.168.56.10:/home/vagrant/init-keys.json /home/vagrant/init-keys.json
 
   echo "Got unseal key, trying to join cluster"
   vault operator raft join "http://${__leader_ip}:8200"

--- a/examples/integrated_storage_ha_cluster_vagrant/tpp-vvw.hcl
+++ b/examples/integrated_storage_ha_cluster_vagrant/tpp-vvw.hcl
@@ -3,21 +3,21 @@ vault {
   token = env("VAULT_TOKEN")
 
   ssh {
-    hostname = "192.168.33.10"
+    hostname = "192.168.56.10"
     username = "vagrant"
     password = "vagrant"
     port = 22
   }
 
   ssh {
-    hostname = "192.168.33.11"
+    hostname = "192.168.56.11"
     username = "vagrant"
     password = "vagrant"
     port = 22
   }
 
   ssh {
-    hostname = "192.168.33.12"
+    hostname = "192.168.56.12"
     username = "vagrant"
     password = "vagrant"
     port = 22
@@ -91,7 +91,7 @@ plugin "venafi-pki-monitor" "pki-monitor" {
 }
 
 plugin "venafi-pki-backend" "pki-backend" {
-  version = "v0.9.0"
+  version = "v0.10.3"
 
   # A role called "web_server" can be used with:
   # vault write pki-backend/issue/web_server common_name=test.test.test

--- a/examples/integrated_storage_ha_cluster_vagrant/vaas-vvw.hcl
+++ b/examples/integrated_storage_ha_cluster_vagrant/vaas-vvw.hcl
@@ -1,23 +1,23 @@
 vault {
-  api_address = "http://192.168.33.10:8200"
+  api_address = "http://192.168.56.10:8200"
   token = env("VAULT_TOKEN")
 
   ssh {
-    hostname = "192.168.33.10"
+    hostname = "192.168.56.10"
     username = "vagrant"
     password = "vagrant"
     port = 22
   }
 
   ssh {
-    hostname = "192.168.33.11"
+    hostname = "192.168.56.11"
     username = "vagrant"
     password = "vagrant"
     port = 22
   }
 
   ssh {
-    hostname = "192.168.33.12"
+    hostname = "192.168.56.12"
     username = "vagrant"
     password = "vagrant"
     port = 22
@@ -85,7 +85,7 @@ plugin "venafi-pki-monitor" "pki-monitor" {
 }
 
 plugin "venafi-pki-backend" "pki-backend" {
-  version = "v0.9.0"
+  version = "v0.10.3"
 
   # A role called "web_server" can be used with:
   # vault write pki-backend/issue/web_server common_name=test.test.test

--- a/examples/single_node_cluster_vagrant/README.md
+++ b/examples/single_node_cluster_vagrant/README.md
@@ -2,7 +2,7 @@
 
 This test environment spins up a VM running a single Vault node.
 This node has the SSH credentials `vagrant` for both the username and password.
-The node's IP addresses is `192.168.33.20`
+The node's IP addresses is `192.168.56.20`
 
 ## Setup
 
@@ -47,7 +47,7 @@ Feel free to also set the `VAULT_ADDR` variable to allow using the normal `vault
 
 ```shell
 $ export VAULT_TOKEN="s.dgjfnskdfgnksd"
-$ export VAULT_ADDR="http://192.168.33.20:8200"
+$ export VAULT_ADDR="http://192.168.56.20:8200"
 $ vault status
 ```
 

--- a/examples/single_node_cluster_vagrant/Vagrantfile
+++ b/examples/single_node_cluster_vagrant/Vagrantfile
@@ -18,7 +18,7 @@ Vagrant.configure("2") do |config|
   config.ssh.password = "vagrant"
 
 config.vm.define "vault-0" do |node|
-  node_ip = "192.168.33.20"
+  node_ip = "192.168.56.20"
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
   node.vm.network "private_network", ip: node_ip

--- a/examples/single_node_cluster_vagrant/tpp-vvw.hcl
+++ b/examples/single_node_cluster_vagrant/tpp-vvw.hcl
@@ -1,9 +1,9 @@
 vault {
-  api_address = "http://192.168.33.20:8200"
+  api_address = "http://192.168.56.20:8200"
   token = env("VAULT_TOKEN")
 
   ssh {
-    hostname = "192.168.33.20"
+    hostname = "192.168.56.20"
     username = "vagrant"
     password = "vagrant"
     port = 22

--- a/examples/single_node_cluster_vagrant/vaas-vvw.hcl
+++ b/examples/single_node_cluster_vagrant/vaas-vvw.hcl
@@ -1,9 +1,9 @@
 vault {
-  api_address = "http://192.168.33.20:8200"
+  api_address = "http://192.168.56.20:8200"
   token = env("VAULT_TOKEN")
 
   ssh {
-    hostname = "192.168.33.20"
+    hostname = "192.168.56.20"
     username = "vagrant"
     password = "vagrant"
     port = 22
@@ -71,7 +71,7 @@ plugin "venafi-pki-monitor" "pki-monitor" {
 }
 
 plugin "venafi-pki-backend" "pki-backend" {
-  version = "v0.9.0"
+  version = "v0.10.3"
 
   # A role called "web_server" can be used with:
   # vault write pki-backend/issue/web_server common_name=test.test.test


### PR DESCRIPTION
This PR covers the changes to the examples to reflect updates that have taken place within vagrant and to confirm that dependency updates allow vvw to still function.

**Changes**
The primary update is to IP addresses used within the examples.  Vagrant provided cli messages instructing to use a new range of IP addresses.  Where appropriate this has been updated.

Along side this the `venafi-pki-backend` vault plugin has been updated from v0.9.0 to v0.10.3 across all of the example 
The `venafi-pki-monitor` plugin remains at v0.9.0 and has not had any releases.

The helm example has been updated to allow different versions to be specified for the each Venafi Vault plugin.

**Testing**
Each of the example completed successfully against VaaS.  Access to a TPP test environment is not available yet and so only IP address and version updates have been made to those files.